### PR TITLE
[ADD] core: add regexp operators to domain expressions and change 'like' behavior

### DIFF
--- a/addons/web/i18n/fr.po
+++ b/addons/web/i18n/fr.po
@@ -5070,6 +5070,22 @@ msgstr "est défini"
 #. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/control_panel/search_utils.js:0
+#: code:addons/web/static/src/js/widgets/domain_selector.js:0
+#, python-format
+msgid "matches"
+msgstr "correspond"
+
+#. module: web
+#. openerp-web
+#: code:addons/web/static/src/js/control_panel/search_utils.js:0
+#: code:addons/web/static/src/js/widgets/domain_selector.js:0
+#, python-format
+msgid "doesn't match"
+msgstr "ne correspond pas"
+
+#. module: web
+#. openerp-web
+#: code:addons/web/static/src/js/control_panel/search_utils.js:0
 #, python-format
 msgid "is true"
 msgstr "est vrai"

--- a/addons/web/i18n/web.pot
+++ b/addons/web/i18n/web.pot
@@ -4911,6 +4911,22 @@ msgstr ""
 #. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/control_panel/search_utils.js:0
+#: code:addons/web/static/src/js/widgets/domain_selector.js:0
+#, python-format
+msgid "matches"
+msgstr ""
+
+#. module: web
+#. openerp-web
+#: code:addons/web/static/src/js/control_panel/search_utils.js:0
+#: code:addons/web/static/src/js/widgets/domain_selector.js:0
+#, python-format
+msgid "doesn't match"
+msgstr ""
+
+#. module: web
+#. openerp-web
+#: code:addons/web/static/src/js/control_panel/search_utils.js:0
 #, python-format
 msgid "is true"
 msgstr ""

--- a/addons/web/static/src/js/control_panel/search_utils.js
+++ b/addons/web/static/src/js/control_panel/search_utils.js
@@ -26,6 +26,8 @@ odoo.define('web.searchUtils', function (require) {
             { symbol: "!=", description: _lt("is not equal to") },
             { symbol: "!=", description: _lt("is set"), value: false },
             { symbol: "=", description: _lt("is not set"), value: false },
+            { symbol: "regexp", description: _lt("matches") },
+            { symbol: "not regexp", description: _lt("doesn't match") },
         ],
         date: [
             { symbol: "=", description: _lt("is equal to") },

--- a/addons/web/static/src/js/widgets/domain_selector.js
+++ b/addons/web/static/src/js/widgets/domain_selector.js
@@ -22,6 +22,8 @@ var operator_mapping = {
     "<=": "<=",
     "ilike": _lt("contains"),
     "not ilike": _lt("does not contain"),
+    "regexp": _lt("matches"),
+    "not regexp": _lt("doesn't match"),
     "in": _lt("in"),
     "not in": _lt("not in"),
 
@@ -868,7 +870,8 @@ var DomainLeaf = DomainNode.extend({
             case "char":
             case "text":
             case "html":
-                operators = _.pick(operator_mapping, "=", "!=", "ilike", "not ilike", "set", "not set", "in", "not in");
+                operators = _.pick(operator_mapping, "=", "!=", "ilike", "not ilike", "regexp", "not regexp",
+                    "set", "not set", "in", "not in");
                 break;
 
             case "many2many":

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -113,6 +113,8 @@ class TestExpression(SavepointCaseWithUserDemo):
         test('like', 'A', ['a', 'ab', 'a b', 'b ab'])
         test('not ilike', 'B', ['0', 'a'])
         test('not like', 'AB', ['0', 'a', 'b', 'a b'])
+        test('regexp', 'b.*b', ['b ab'])
+        test('not regexp', '[ab]+', ['0', 'a b', 'b ab'])
 
     def test_09_hierarchy_filtered_domain(self):
         Partner = self.env['res.partner']

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -942,7 +942,8 @@ class expression(object):
                         push_result(expr, params)
 
                 elif field.translate is True and right:
-                    need_wildcard = operator in ('like', 'ilike', 'not like', 'not ilike')
+                    need_wildcard = (operator in ('like', 'ilike', 'not like', 'not ilike')
+                                     and '%' not in right and '_' not in right)
                     sql_operator = {
                         '=like': 'like', '=ilike': 'ilike', 'regexp': '~*', 'not regexp': '!~*'
                     }.get(operator, operator)
@@ -1066,7 +1067,8 @@ class expression(object):
                 query, params = self.__leaf_to_sql((left, '=', right), model, alias)
 
         else:
-            need_wildcard = operator in ('like', 'ilike', 'not like', 'not ilike')
+            need_wildcard = (operator in ('like', 'ilike', 'not like', 'not ilike')
+                             and '%' not in right and '_' not in right)
             sql_operator = {
                 '=like': 'like', '=ilike': 'ilike','regexp': '~*','not regexp': '!~*'
             }.get(operator, operator)


### PR DESCRIPTION
1. Add regexp operator for domains and filters.
2. Change "like" behavior to surround with wildcards only if there's no wildcard in the operand.