### PR TITLE
[FIX] export: always export m2m as comma-separated list

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -993,7 +993,7 @@ class BaseModel(metaclass=MetaModel):
 
                         # in import_compat mode, m2m should always be exported as
                         # a comma-separated list of xids or names in a single cell
-                        if import_compatible and field.type == 'many2many':
+                        if field.type == 'many2many':
                             index = None
                             # find out which subfield the user wants & its
                             # location as we might not get it as the first


### PR DESCRIPTION
Odoo export many2many fields on separated lines by default (same as one2many)
This change will force m2m to be exported as comma-separated list instead all the time.

fix [#2227](https://github.com/sasmrm/mrm_odoo/issues/2227)