### PR TITLE
[FIX] export: export m2m as comma-separated list unless ...

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -965,7 +965,8 @@ class BaseModel(metaclass=MetaModel):
 
                         # in import_compat mode, m2m should always be exported as
                         # a comma-separated list of xids or names in a single cell
-                        if field.type == 'many2many':
+                        # MRM-patch: also export comma-separated list if m2m field is specified without nested field
+                        if (import_compatible or len(path) == 1) and field.type == 'many2many':
                             index = None
                             # find out which subfield the user wants & its
                             # location as we might not get it as the first


### PR DESCRIPTION
This is a fix of this PR: https://github.com/sasmrm/odoo-server/pull/7
Its commit could be squashed together.

L'export des m2m en liste séparée par des virgules empêche l'export des champs enfant d'une telle relation, de cette facon:
![image](https://github.com/sasmrm/odoo-server/assets/8747037/a200dbe8-2026-4984-b2ed-1a73ecc04fbe)
Dans ce cas, le premier champ (ici Code) contenait la liste séparée par des virgules et les suivants étaient vides.

Cette PR corrige cela en restaurant le comportement par défaut de Odoo quand l'export stipule des champs enfants (nested fields) d'une relation x2m.
Elle maintient également l'export en liste séparée par des virgules quand le champ m2m est sélectionné directement (cad sans mentionner un champ enfant particulier), ce qui permet notamment que le quick export exporte en liste séparée par des virgules.

Exemples:
1. Liste séparée par des virgules
    - Quick export
    - Import-compatible export
![image](https://github.com/sasmrm/odoo-server/assets/8747037/ab21470f-8afc-497e-8e08-944337fbfc38)
    - Export m2m field directly
![image](https://github.com/sasmrm/odoo-server/assets/8747037/b543a1cb-767f-4714-9d05-fa8be500a411)

Résultat:
![image](https://github.com/sasmrm/odoo-server/assets/8747037/9b758dfe-02b9-4593-92f0-fa98a8c27b9c)
Une ligne par record exporté, m2m en CSV

2. Un record par ligne
    - Export not import-compatible d'un champ enfant
![image](https://github.com/sasmrm/odoo-server/assets/8747037/928a6710-9118-417a-8d4c-db5e37c6abf6)

Résultat:
![image](https://github.com/sasmrm/odoo-server/assets/8747037/bf2580c5-4ad4-421c-b51f-f1b1b78062f3)
Une ligne par record enfant du m2m




NB: Désolé pour le franglais