### PR TITLE
[FIX] fields: trim char fields server-side

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1881,9 +1881,14 @@ class Char(_String):
     def convert_to_column(self, value, record, values=None, validate=True):
         if value is None or value is False:
             return None
+        # we need to convert the string to a unicode object to be able
+        # to evaluate its length (and possibly truncate it) reliably
+        return super().convert_to_column(pycompat.to_text(value)[:self.size], record, values, validate)
+
+    def _convert_from_cache_to_column(self, value):
         # Implement server-side string trimming
         if type(value) == str:
-            if self.trim :
+            if self.trim:
                 value = value.strip()
             # Save null instead of "" (string empty)
             if value == "":
@@ -1897,9 +1902,7 @@ class Char(_String):
             if all(type(val) == str for _, val in items):
                 for key, val in items:
                     value[key] = val.strip()
-        # we need to convert the string to a unicode object to be able
-        # to evaluate its length (and possibly truncate it) reliably
-        return super().convert_to_column(pycompat.to_text(value)[:self.size], record, values, validate)
+        return super()._convert_from_cache_to_column(value)
 
     def convert_to_cache(self, value, record, validate=True):
         if value is None or value is False:


### PR DESCRIPTION
fix https://github.com/sasmrm/mrm_odoo/issues/2497

A squasher avec le commit précédent portant le même nom

Cette PR change le patch qui trim les champs Char car la version précédente ne fonctionnait pas pour les champs traduisibles.
En effet, la fonction `_flush` qui déclenche la mise à jour en base de données contient
https://github.com/sasmrm/odoo-server/blob/ec1c9a715b3d3eae315e90545ca0607d545dce29/odoo/models.py#L5636-L5641
On voit bien ici que dans le cas d'un champ traduisible, la fonction `_convert_from_cache_to_column` est appelée directement alors que dans le cas d'un champ non traduisible, c'est `convert_to_column` qui est appelée (et qui elle même appelera `_convert_from_cache_to_column`)