### PR TITLE
[FIX] base: Monetary fields exports behave like Float fields

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1643,6 +1643,11 @@ class Monetary(Field):
     def convert_to_write(self, value, record):
         return value
 
+    def convert_to_export(self, value, record):
+        if value or value == 0.0:
+            return value
+        return ''
+
 
 class _String(Field):
     """ Abstract class for string fields. """


### PR DESCRIPTION
Demandé par Kaiser dans l'email ["Question sur l'exportation du prix d'achat des Souches"](https://github.com/sasmrm/odoo-server/files/13510619/Discussion.pdf)

Aligne le fonctionnement de l'export des Monetary avec celui des Float pour des valeurs nulles.

Egalement soumis sur le repo officiel de Odoo
https://github.com/odoo/odoo/pull/144305